### PR TITLE
Improve HTTP status

### DIFF
--- a/src/main/java/com/example/demo/security/configuration/ApplicationSecurity.java
+++ b/src/main/java/com/example/demo/security/configuration/ApplicationSecurity.java
@@ -57,7 +57,6 @@ public class ApplicationSecurity extends WebSecurityConfigurerAdapter { //todo c
 
         // This exception handling code ensures that the server will return HTTP status 401 (Unauthorized)
         // if any error occurs during authentication process
-        // todo: this is not what I want. It is causing nonsense urls to return 401 unauthorised errors. Which is not useful
         http.exceptionHandling()
                 .authenticationEntryPoint(
                         (request, response, ex) ->
@@ -84,5 +83,4 @@ public class ApplicationSecurity extends WebSecurityConfigurerAdapter { //todo c
         // AuthenticationManager has one method only: authenticate()
         return super.authenticationManagerBean();
     }
-
 }

--- a/src/main/java/com/example/demo/security/configuration/ApplicationSecurity.java
+++ b/src/main/java/com/example/demo/security/configuration/ApplicationSecurity.java
@@ -52,18 +52,18 @@ public class ApplicationSecurity extends WebSecurityConfigurerAdapter { //todo c
 
         // authorises any request via /auth/login to enter without authentication
         http.authorizeRequests()
-                .antMatchers("/auth/login", "/h2-console/**", "/public/**").permitAll()
-                .anyRequest().authenticated();
+                .antMatchers("/private/**").authenticated()
+                .anyRequest().permitAll();
 
         // This exception handling code ensures that the server will return HTTP status 401 (Unauthorized)
         // if any error occurs during authentication process
         // todo: this is not what I want. It is causing nonsense urls to return 401 unauthorised errors. Which is not useful
         http.exceptionHandling()
                 .authenticationEntryPoint(
-                        (request, response, ex) -> response.sendError(
+                        (request, response, ex) ->
+                            response.sendError(
                                 HttpServletResponse.SC_UNAUTHORIZED,
-                                ex.getMessage()
-                        )
+                                ex.getMessage())
                 );
 
         // We add our custom filter before the UsernameAndPasswordAuthenticationFilter in Spring Security filters chain.

--- a/src/main/java/com/example/demo/security/token/JwtTokenUtil.java
+++ b/src/main/java/com/example/demo/security/token/JwtTokenUtil.java
@@ -55,6 +55,8 @@ public class JwtTokenUtil {
             log.error("Claim to be verified is missing", ex);
         } catch (IncorrectClaimException ex) {
             log.error("Incorrect claim");
+        } catch (Exception ex) {
+            log.error("There is a problem with the JWT");
         }
         return false;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,4 @@ spring.h2.console.enabled=true
 spring.datasource.generate-unique-name=false
 spring.datasource.name=matcher
 logging.level.org.springframework.jdbc=DEBUG
+server.error.include-message=always

--- a/src/test/java/com/example/demo/WebAndSecurity/LoginValidationTest.java
+++ b/src/test/java/com/example/demo/WebAndSecurity/LoginValidationTest.java
@@ -45,7 +45,6 @@ public class LoginValidationTest {
     @MockBean
     private Matcher matcher;
 
-
     @BeforeEach
     public void setup() throws Exception {
         this.mvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext).apply(springSecurity()).build();


### PR DESCRIPTION
Minimal changes

- I've changed the security settings so that we only authenticate the URLs beginning in /Private/.
- Previously a mistyped URL would result in a 401 unauthorized error. Now we seem to be getting 404 errors which is an improvement.