### PR TITLE
Remove explicit usernames

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,10 @@ test {
 jacocoTestReport {
 	dependsOn test
 }
-buildScan {
-	termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-	termsOfServiceAgree = 'yes'
+
+if (hasProperty('buildScan')) {
+	buildScan {
+		termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+		termsOfServiceAgree = 'yes'
+	}
 }

--- a/src/main/java/com/example/demo/matcher/MatcherController.java
+++ b/src/main/java/com/example/demo/matcher/MatcherController.java
@@ -92,28 +92,28 @@ public class MatcherController {
     }
 
     @PostMapping(value="/private/make/order")
-    public ResponseEntity<MakeOrderReturn> makeOrder(@Valid @RequestBody NewOrderParams newOrderParams, @RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
+    public ResponseEntity<NewOrderReturn> makeOrder(@Valid @RequestBody NewOrderParams newOrderParams, @RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
+        String username;
         try{
-            if (!getUsernameFromAuthHeader(authHeader).equals(newOrderParams.getUsername()))
-                return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+            username = getUsernameFromAuthHeader(authHeader);
         }
         catch (Exception e) {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
 
         OrderObj newOrder = new OrderObj(
-                userService.getUser(newOrderParams.getUsername()),
+                userService.getUser(username),
                 BigDecimal.valueOf(newOrderParams.getPrice()),
                 BigDecimal.valueOf(newOrderParams.getQuantity()),
                 newOrderParams.getAction().equals("buy") ? OrderAction.BUY : OrderAction.SELL
-                );
+        );
 
         matcher.match(newOrder);
 
-        return ResponseEntity.ok(new MakeOrderReturn(
+        return ResponseEntity.ok(new NewOrderReturn(
                 orderService.getOrderbook(OrderAction.BUY),
                 orderService.getOrderbook(OrderAction.SELL),
-                orderService.getOrderbook(OrderAction.BUY, newOrderParams.getUsername()),
+                orderService.getOrderbook(OrderAction.BUY, username),
                 orderService.getOrderbook(OrderAction.SELL, newOrder.getUser().getUsername()),
                 tradeService.getRecent(),
                 orderService.getOrderDepth(OrderAction.BUY),

--- a/src/main/java/com/example/demo/matcher/MatcherController.java
+++ b/src/main/java/com/example/demo/matcher/MatcherController.java
@@ -46,11 +46,10 @@ public class MatcherController {
         return jwtTokenUtil.getSubject(token).split(",")[1];
     }
 
-    @GetMapping(value = "/private/orderbook/buy/{username}")
-    public ResponseEntity<List<OrderbookItem>> orderbook_buy(@PathVariable String username, @RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
+    @GetMapping(value = "/private/orderbook/buy")
+    public ResponseEntity<List<OrderbookItem>> orderbook_buy(@RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
         try {
-            if (!getUsernameFromAuthHeader(authHeader).equals(username))
-                return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+            String username = getUsernameFromAuthHeader(authHeader);
             return ResponseEntity.ok(orderService.getOrderbook(OrderAction.BUY, username));
         }
         catch(Exception e) {
@@ -65,10 +64,9 @@ public class MatcherController {
     }
 
     @GetMapping(value = "/private/orderbook/sell/{username}")
-    public ResponseEntity<List<OrderbookItem>> orderbook_sell(@PathVariable String username, @RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
+    public ResponseEntity<List<OrderbookItem>> orderbook_sell(@RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
         try {
-            if (!getUsernameFromAuthHeader(authHeader).equals(username))
-                return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+            String username = getUsernameFromAuthHeader(authHeader);
             return ResponseEntity.ok(orderService.getOrderbook(OrderAction.SELL, username));
         }
         catch(Exception e) {

--- a/src/main/java/com/example/demo/matcher/models/NewOrderParams.java
+++ b/src/main/java/com/example/demo/matcher/models/NewOrderParams.java
@@ -11,7 +11,6 @@ import javax.validation.constraints.Pattern;
 
 @ToString @AllArgsConstructor @Getter
 public class NewOrderParams {
-    String username;
     @Min(value = OrderObj.minPrice) @Max(value = OrderObj.maxPrice)
     double price;
     @Min(value = OrderObj.minQuantity) @Max(value = OrderObj.maxQuantity)

--- a/src/main/java/com/example/demo/matcher/models/NewOrderReturn.java
+++ b/src/main/java/com/example/demo/matcher/models/NewOrderReturn.java
@@ -7,7 +7,7 @@ import lombok.ToString;
 import java.util.List;
 
 @AllArgsConstructor @ToString @Getter
-public class MakeOrderReturn {
+public class NewOrderReturn {
     private final List<OrderbookItem> buy;
     private final List<OrderbookItem> sell;
     private final List<OrderbookItem> buyPrivate;

--- a/src/test/java/com/example/demo/WebAndSecurity/NewOrderValidationTest.java
+++ b/src/test/java/com/example/demo/WebAndSecurity/NewOrderValidationTest.java
@@ -69,7 +69,7 @@ public class NewOrderValidationTest {
     @Test
     void ItShouldCheckNewOrderPriceIsNotTooSmall() throws Exception {
         NewOrderParams newOrderParams = new NewOrderParams(
-                "fakeUsername", -1, 1, "buy"
+                -1, 1, "buy"
         );
 
         // API call
@@ -87,7 +87,7 @@ public class NewOrderValidationTest {
     @Test
     void ItShouldCheckNewOrderPriceIsNotTooLarge() throws Exception {
         NewOrderParams newOrderParams = new NewOrderParams(
-                "fakeUsername", 1000000001, 1, "buy"
+                1000000001, 1, "buy"
         );
 
         // API call
@@ -105,7 +105,7 @@ public class NewOrderValidationTest {
     @Test
     void ItShouldCheckNewOrderQuantityIsNotTooSmall() throws Exception {
         NewOrderParams newOrderParams = new NewOrderParams(
-                "fakeUsername", 1, -1, "buy"
+                1, -1, "buy"
         );
 
         // API call
@@ -123,7 +123,7 @@ public class NewOrderValidationTest {
     @Test
     void ItShouldCheckNewOrderQuantityIsNotTooLarge() throws Exception {
         NewOrderParams newOrderParams = new NewOrderParams(
-                "fakeUsername", 1, 1000000001, "buy"
+                 1, 1000000001, "buy"
         );
 
         // API call
@@ -141,7 +141,7 @@ public class NewOrderValidationTest {
     @Test
     void ItShouldCheckNewOrderActionIsBuyOrSell() throws Exception {
         NewOrderParams newOrderParams = new NewOrderParams(
-                "fakeUsername", 1, 1, "badAction"
+                 1, 1, "badAction"
         );
 
         // API call

--- a/src/test/java/com/example/demo/WebAndSecurity/PrivateEndpointsWithTokenTest.java
+++ b/src/test/java/com/example/demo/WebAndSecurity/PrivateEndpointsWithTokenTest.java
@@ -9,7 +9,6 @@ import com.example.demo.matcher.services.TradeService;
 import com.example.demo.security.service.UserService;
 import com.example.demo.security.token.JwtTokenUtil;
 import com.example.demo.security.userInfo.AppUser;
-import org.junit.Before;
 import org.junit.jupiter.api.*;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -180,7 +179,7 @@ public class PrivateEndpointsWithTokenTest {
                 .andReturn();
 
         // check result
-        MakeOrderReturn expectedReturn = new MakeOrderReturn(
+        NewOrderReturn expectedReturn = new NewOrderReturn(
                 List.of(expectedOrderbookItem),
                 List.of(),
                 List.of(expectedOrderbookItem),

--- a/src/test/java/com/example/demo/WebAndSecurity/PublicEndpointsAndLockedPrivateEndpointsTest.java
+++ b/src/test/java/com/example/demo/WebAndSecurity/PublicEndpointsAndLockedPrivateEndpointsTest.java
@@ -157,7 +157,6 @@ public class PublicEndpointsAndLockedPrivateEndpointsTest {
         OrderObj newOrder = TestUtils.makeOrder(1 ,1, "b");
 
         NewOrderParams newOrderParams = new NewOrderParams(
-                newOrder.getUser().getUsername(),
                 newOrder.getPrice().doubleValue(),
                 newOrder.getQuantity().doubleValue(),
                 "buy"
@@ -198,7 +197,6 @@ public class PublicEndpointsAndLockedPrivateEndpointsTest {
         OrderObj newOrder = TestUtils.makeOrder(1 ,1, "b");
 
         NewOrderParams newOrderParams = new NewOrderParams(
-                newOrder.getUser().getUsername(),
                 newOrder.getPrice().doubleValue(),
                 newOrder.getQuantity().doubleValue(),
                 "buy"


### PR DESCRIPTION
close #27. If the client has a valid JWT then there is no need for them to specify an account for posting new orders or accessing private orders